### PR TITLE
Migrate kotlin serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,21 +73,21 @@ Gradle version: 8.13.2 <br />
 
 ## References - Useful Links
 
-https://android-developers.googleblog.com/2024/10/introducing-ink-api-jetpack-library.html <br />
-https://developer.android.com/develop/ui/compose/touch-input/stylus-input/about-ink-api <br />
-https://developer.android.com/develop/ui/compose/touch-input/stylus-input/ink-api-modules <br />
-https://developer.android.com/develop/ui/compose/touch-input/stylus-input/ink-api-setup <br />
-https://developer.android.com/develop/ui/compose/touch-input/stylus-input/ink-api-draw-stroke <br />
-https://developer.android.com/develop/ui/compose/touch-input/stylus-input/ink-api-geometry-apis <br />
-https://developer.android.com/develop/ui/compose/touch-input/stylus-input/ink-api-state-preservation <br />
-https://developer.android.com/jetpack/androidx/releases/ink <br />
-https://x.com/AndroidDev/status/1843758267404554563 <br />
-https://issuetracker.google.com/issues/383380976 <br />
+- https://android-developers.googleblog.com/2024/10/introducing-ink-api-jetpack-library.html <br />
+- https://developer.android.com/develop/ui/compose/touch-input/stylus-input/about-ink-api <br />
+- https://developer.android.com/develop/ui/compose/touch-input/stylus-input/ink-api-modules <br />
+- https://developer.android.com/develop/ui/compose/touch-input/stylus-input/ink-api-setup <br />
+- https://developer.android.com/develop/ui/compose/touch-input/stylus-input/ink-api-draw-stroke <br />
+- https://developer.android.com/develop/ui/compose/touch-input/stylus-input/ink-api-geometry-apis <br />
+- https://developer.android.com/develop/ui/compose/touch-input/stylus-input/ink-api-state-preservation <br />
+- https://developer.android.com/jetpack/androidx/releases/ink <br />
+- https://x.com/AndroidDev/status/1843758267404554563 <br />
+- https://issuetracker.google.com/issues/383380976 <br />
 
 ### Important Resources for optimize storage to save the Stroke in Room Database (Examples) <br />
 
-https://developer.android.com/develop/ui/compose/touch-input/stylus-input/ink-api-state-preservation <br />
-https://github.com/android/cahier <br />
-https://github.com/android/cahier/blob/main/app/src/main/java/com/example/cahier/data/OfflineNotesRepository.kt <br />
-https://github.com/android/cahier/blob/main/app/src/main/java/com/example/cahier/ui/Converters.kt <br />
-https://developer.android.com/reference/kotlin/androidx/ink/storage/package-summary#(androidx.ink.strokes.StrokeInputBatch).encode(java.io.OutputStream) <br />
+- https://developer.android.com/develop/ui/compose/touch-input/stylus-input/ink-api-state-preservation <br />
+- https://github.com/android/cahier <br />
+- https://github.com/android/cahier/blob/main/app/src/main/java/com/example/cahier/data/OfflineNotesRepository.kt <br />
+- https://github.com/android/cahier/blob/main/app/src/main/java/com/example/cahier/ui/Converters.kt <br />
+- https://developer.android.com/reference/kotlin/androidx/ink/storage/package-summary#(androidx.ink.strokes.StrokeInputBatch).encode(java.io.OutputStream) <br />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,8 +87,8 @@ dependencies {
     implementation(libs.androidx.room.runtime)
     ksp(libs.androidx.room.compiler)
     implementation(libs.androidx.room.ktx)
-    //Gson
-    implementation(libs.gson)
+    // Kotlin Serialization
+    implementation(libs.kotlinx.serialization.json)
     //Unit Test
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -47,37 +47,3 @@
 }
 
 # End Ink Api Proguard Rules
-
-##---------------Begin: proguard configuration for Gson  ----------
-# Gson uses generic type information stored in a class file when working with fields. Proguard
-# removes such information by default, so configure it to keep all of it.
--keepattributes Signature
-
-# For using GSON @Expose annotation
--keepattributes *Annotation*
-
-# Gson specific classes
--dontwarn sun.misc.**
-#-keep class com.google.gson.stream.** { *; }
-
-# Application classes that will be serialized/deserialized over Gson
- -keep class com.nicos.ink_api_compose.data.database.entities.** { <fields>; }
- -keep class com.nicos.ink_api_compose.data.stroke_converter.** { <fields>; }
-
-# Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
-# JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
--keep class * extends com.google.gson.TypeAdapter
--keep class * implements com.google.gson.TypeAdapterFactory
--keep class * implements com.google.gson.JsonSerializer
--keep class * implements com.google.gson.JsonDeserializer
-
-# Prevent R8 from leaving Data object members always null
--keepclassmembers,allowobfuscation class * {
-  @com.google.gson.annotations.SerializedName <fields>;
-}
-
-# Retain generic signatures of TypeToken and its subclasses with R8 version 3.0 and higher.
--keep,allowobfuscation class com.google.gson.reflect.TypeToken
--keep,allowobfuscation class * extends com.google.gson.reflect.TypeToken
-
-##---------------End: proguard configuration for Gson  ----------

--- a/app/src/main/java/com/nicos/ink_api_compose/data/database/entities/StrokeEntity.kt
+++ b/app/src/main/java/com/nicos/ink_api_compose/data/database/entities/StrokeEntity.kt
@@ -11,5 +11,5 @@ data class StrokeEntity(
     val brushColor: Long,
     val brushEpsilon: Float,
     val stockBrush: SerializedStockBrush,
-    val strokeInputs: String?,
+    val strokeInputs: String,
 )

--- a/app/src/main/java/com/nicos/ink_api_compose/data/stroke_converter/StrokeConverter.kt
+++ b/app/src/main/java/com/nicos/ink_api_compose/data/stroke_converter/StrokeConverter.kt
@@ -25,7 +25,7 @@ class StrokeConverters {
             stockBrushToEnumValues.entries.associate { (key, value) -> value to key }
     }
 
-    fun serializeStrokeToEntity(stroke: List<Stroke>): StrokeEntity {
+    fun serializeStrokeToEntity(stroke: Set<Stroke>): StrokeEntity {
         val serializedBrush = serializeBrush(stroke.last().brush)
         val encodedSerializedInputs = stroke.map {
             ByteArrayOutputStream().use { outputStream ->

--- a/app/src/main/java/com/nicos/ink_api_compose/data/stroke_converter/StrokeConverter.kt
+++ b/app/src/main/java/com/nicos/ink_api_compose/data/stroke_converter/StrokeConverter.kt
@@ -6,15 +6,12 @@ import androidx.ink.storage.decode
 import androidx.ink.storage.encode
 import androidx.ink.strokes.Stroke
 import androidx.ink.strokes.StrokeInputBatch
-import com.google.gson.Gson
-import com.google.gson.GsonBuilder
 import com.nicos.ink_api_compose.data.database.entities.StrokeEntity
+import kotlinx.serialization.json.Json
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 
 class StrokeConverters {
-
-    private val gson: Gson = GsonBuilder().create()
 
     companion object {
         private val stockBrushToEnumValues =
@@ -28,23 +25,25 @@ class StrokeConverters {
             stockBrushToEnumValues.entries.associate { (key, value) -> value to key }
     }
 
-    fun serializeStrokeToEntity(stroke: Stroke): StrokeEntity {
-        val serializedBrush = serializeBrush(stroke.brush)
-        val encodedSerializedInputs = ByteArrayOutputStream().use { outputStream ->
-            stroke.inputs.encode(outputStream)
-            outputStream.toByteArray()
+    fun serializeStrokeToEntity(stroke: List<Stroke>): StrokeEntity {
+        val serializedBrush = serializeBrush(stroke.last().brush)
+        val encodedSerializedInputs = stroke.map {
+            ByteArrayOutputStream().use { outputStream ->
+                it.inputs.encode(outputStream)
+                outputStream.toByteArray()
+            }
         }
         return StrokeEntity(
             brushSize = serializedBrush.size,
             brushColor = serializedBrush.color,
             brushEpsilon = serializedBrush.epsilon,
             stockBrush = serializedBrush.stockBrush,
-            strokeInputs = gson.toJson(encodedSerializedInputs),
+            strokeInputs = Json.encodeToString(encodedSerializedInputs),
         )
     }
 
 
-    fun deserializeEntityToStroke(entity: StrokeEntity): Stroke {
+    fun deserializeEntityToStroke(entity: StrokeEntity): Set<Stroke> {
         val serializedBrush =
             SerializedBrush(
                 size = entity.brushSize,
@@ -53,14 +52,16 @@ class StrokeConverters {
                 stockBrush = entity.stockBrush,
             )
 
-        val decodedSerializedInputs = gson.fromJson(entity.strokeInputs, ByteArray::class.java)
-        val inputsStroke = ByteArrayInputStream(decodedSerializedInputs).use { inputStream ->
-            StrokeInputBatch.decode(inputStream)
+        val decodedSerializedInputs = Json.decodeFromString<List<ByteArray>>(entity.strokeInputs)
+        val inputsStroke = decodedSerializedInputs.map {
+            ByteArrayInputStream(it).use { inputStream ->
+                StrokeInputBatch.decode(inputStream)
+            }
         }
 
         val brush = deserializeBrush(serializedBrush)
 
-        return Stroke(brush = brush, inputs = inputsStroke)
+        return inputsStroke.map { Stroke(brush = brush, inputs = it) }.toSet()
     }
 
     private fun serializeBrush(brush: Brush): SerializedBrush {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ kspVersion = "2.3.4"
 roomVersion = "2.8.4"
 hiltVersion = "2.57.2"
 hiltCompilerVersion = "1.3.0"
-gsonVersion = "2.13.2"
 composeHiltNavigationVersion = "1.3.0"
 kotlinSerializationVersion = "1.9.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ hiltVersion = "2.57.2"
 hiltCompilerVersion = "1.3.0"
 gsonVersion = "2.13.2"
 composeHiltNavigationVersion = "1.3.0"
+kotlinSerializationVersion = "1.9.0"
 
 [libraries]
 # Architecture
@@ -52,8 +53,8 @@ androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = 
 dagger-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hiltVersion" }
 dagger-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hiltVersion" }
 hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltCompilerVersion" }
-# Gson
-gson = { group = "com.google.code.gson", name = "gson", version.ref = "gsonVersion" }
+# Kotlin Serialization
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinSerializationVersion" }
 # Unit Test
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }


### PR DESCRIPTION
### **What's new:**
- Optimized stroke data persistence using Room for better performance and efficiency.
  - Migrated from Gson to Kotlin Serialization.
  - Check the Reference Useful Links.
- Updated Ink API to version 1.0.0.
- Upgraded Kotlin to version 2.3.0.
- Upgraded KSP to version 2.3.4.
- Jetpack Compose libraries updated to BOM 2025.12.01.
- Updated all dependencies to their latest available versions.
- Updated the README file for clarity and accuracy.